### PR TITLE
made altitude_corrected more careful

### DIFF
--- a/src/AvionicsCalculations.cpp
+++ b/src/AvionicsCalculations.cpp
@@ -110,7 +110,8 @@ bool Avionics::calcIncentives() {
   lasController.updateConstants(data.LAS_CONSTANTS);
   LasagnaController::Input lasInput;
   lasInput.h_rel = data.ALTITUDE_BAROMETER;
-  lasInput.h_abs = data.ALTITUDE_CORRECTED;
+  float las_h_abs = data.USE_ALTITUDE_CORRECTED ? data.ALTITUDE_CORRECTED : data.ALTITUDE_BAROMETER;
+  lasInput.h_abs = las_h_abs;
   lasInput.op = isnan(data.OVERPRESSURE_FILT) ? 0 : data.OVERPRESSURE_FILT;
   
   sun_ctr++;

--- a/src/AvionicsUplink.cpp
+++ b/src/AvionicsUplink.cpp
@@ -166,6 +166,7 @@ void Avionics::updateConstant(uint8_t index, float value) {
   else if (index == 102) data.DEADMAN_TIME = value * 1000. * 60 * 60; // hours
   else if (index == 123) data.RB_COOLDOWN = value * 1000;
   else if (index == 124) data.SWITCH_TO_MANUAL = (bool)value;
+  else if (index == 125) data.USE_ALTITUDE_CORRECTED = (bool)value;       // Select weather or not the controller should use ALTITUDE_CORRECTED
 }
 
 /*

--- a/src/Data.h
+++ b/src/Data.h
@@ -135,6 +135,7 @@ struct DataFrame {
   float      BALLAST_LAST_ACTION_CONSTANT    =      BALLAST_LAST_ACTION_DEFAULT;
 
   float     DLDT_SCALE                       =               DLDT_SCALE_DEFAULT;
+  bool      USE_ALTITUDE_CORRECTED           =                             true;
 
 
 /*******************************  EXTRA DATA  *********************************/

--- a/src/Filters.cpp
+++ b/src/Filters.cpp
@@ -175,7 +175,7 @@ float Filters::update_voltage_supercap(float v) {
 }
 
 void Filters::correctAltitude(struct DataFrame &data){
-  if(data.NUM_SATS_GPS >= 6){
+  if( (data.NUM_SATS_GPS >= 6) && (data.GPS_LAST_NEW - data.TIME < 1000*60*5) && (fabs(data.ALTITUDE_GPS - data.ALTITUDE_BAROMETER) < 1000)) {
     data.ALTITUDE_OFFSET = data.ALTITUDE_OFFSET*(1-data.ALTITUDE_OFFSET_GAIN) + (data.ALTITUDE_GPS - data.ALTITUDE_BAROMETER)*data.ALTITUDE_OFFSET_GAIN;
   }
   data.ALTITUDE_CORRECTED = data.ALTITUDE_BAROMETER + data.ALTITUDE_OFFSET;

--- a/src/Filters.cpp
+++ b/src/Filters.cpp
@@ -175,7 +175,7 @@ float Filters::update_voltage_supercap(float v) {
 }
 
 void Filters::correctAltitude(struct DataFrame &data){
-  if( (data.NUM_SATS_GPS >= 6) && (data.GPS_LAST_NEW - data.TIME < 1000*60*5) && (fabs(data.ALTITUDE_GPS - data.ALTITUDE_BAROMETER) < 1000)) {
+  if( (data.NUM_SATS_GPS >= 6) && (data.TIME - data.GPS_LAST_NEW < 1000*60*5) && (fabs(data.ALTITUDE_GPS - data.ALTITUDE_BAROMETER) < 1000)) {
     data.ALTITUDE_OFFSET = data.ALTITUDE_OFFSET*(1-data.ALTITUDE_OFFSET_GAIN) + (data.ALTITUDE_GPS - data.ALTITUDE_BAROMETER)*data.ALTITUDE_OFFSET_GAIN;
   }
   data.ALTITUDE_CORRECTED = data.ALTITUDE_BAROMETER + data.ALTITUDE_OFFSET;


### PR DESCRIPTION
Now, `ALTITUDE_OFFSET` only updates if there are enough gps satellites, the gps coordinates have changed within the last 5 minutes, and the difference between the GPS and barometric altitudes is less that 1km.

No testing as not a major logic change 