### PR TITLE
tweeked lasagna for better inflight reboot behavior

### DIFF
--- a/src/LasagnaController.cpp
+++ b/src/LasagnaController.cpp
@@ -47,7 +47,7 @@ bool LasagnaController::update(Input input){
           launch_h = input.h_rel;
         }
         is_first_call = false;
-      } else if(input.h_rel - launch_h > constants.launch_h_thresh) state.status = ASCENT;
+      } else if(pasta_abs(input.h_rel - launch_h) > constants.launch_h_thresh) state.status = ASCENT;
       break;
     case ASCENT:
       if(input.h_rel > constants.equil_h_thresh) state.status = EQUIL;
@@ -106,7 +106,7 @@ void LasagnaController::innerLoop(float input_h){
    */
   float deadband_effort = 0;
   float thresh = constants.k_v*constants.k_h*constants.ss_error_thresh;
-  if(jankabs(state.effort)-thresh > 0){
+  if(pasta_abs(state.effort)-thresh > 0){
     deadband_effort = state.effort + ((state.effort<0)-(state.effort>0))*thresh;
   }
   deadband_effort = pasta_clamp(deadband_effort,-state.v_dldt,constants.b_dldt);

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -24,11 +24,11 @@
 /*
 Custom functions define here so they can be compiled on both x64 and ARM
 */
-#define jankabs(x) ((x>0)-(x<0))*x
+#define jankabs(x) (((x)>0)-((x)<0))*(x)
 
 template<class T> const T pasta_abs(const T x)
 {
-    return ((x>0)-(x<0))*x;
+    return (((x)>0)-((x)<0))*(x);
 }
 
 template<class T> const T pasta_max(const T a, const T b)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15115966/46067271-4c244500-c12b-11e8-8ee9-63820e2ea5d6.png)

In response to comment on last PR, lasagna will now start up if the altitude changes by more than the `launch_h_thresh` (default is 300m) from the altitude that it was initialized at. Before, lasagna would only start up properly after an in flight reboot if the balloon was either above the `equil_h_thresh` (10km) or if it was rising. I tested other start conditions besides the one shown, but the above plot gives an example of an in flight reboot at low altitude while the balloon is falling.